### PR TITLE
Functionality added to add Pawns to chessboard and move pawns.

### DIFF
--- a/ChessProject-Csharp/src/Chess.csproj
+++ b/ChessProject-Csharp/src/Chess.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SolarWinds.MSP.Chess</RootNamespace>
     <AssemblyName>SolarWinds.MSP.Chess</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/ChessProject-Csharp/src/ChessBoard.cs
+++ b/ChessProject-Csharp/src/ChessBoard.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace SolarWinds.MSP.Chess
 {
@@ -6,21 +7,78 @@ namespace SolarWinds.MSP.Chess
     {
         public static readonly int MaxBoardWidth = 7;
         public static readonly int MaxBoardHeight = 7;
-        private Pawn[,] pieces;
+        internal Pawn[,] pieces;
+       
 
         public ChessBoard ()
         {
             pieces = new Pawn[MaxBoardWidth, MaxBoardHeight];
         }
 
-        public void Add(Pawn pawn, int xCoordinate, int yCoordinate, PieceColor pieceColor)
+      
+        /// <summary>
+        /// Method to add pawn to the board, validates if board position is valid and if so adds it the pawn.
+        /// </summary>
+        /// <param name="pawn">Pawn object to be added</param>
+        /// <param name="xCoordinate">X-Coordinate to place pawn</param>
+        /// <param name="yCoordinate">Y-coordinate to place pawn</param>
+        /// <param name="pieceColour">Colour of pawn to add to the board (Black or White)</param>
+        public void Add(Pawn pawn, int xCoordinate, int yCoordinate, PieceColor pieceColour)
         {
-            throw new NotImplementedException("Need to implement ChessBoard.Add()");
+            
+            //check if coordinates provided are legal board position
+            bool legalPos = IsLegalBoardPosition(xCoordinate, yCoordinate);
+            if (!legalPos)
+            {
+                Console.WriteLine($" xcoord: {xCoordinate} and ycoord: {yCoordinate} is not a legal board position");
+                //Not legal so set x and y coords to -1.
+                pawn.XCoordinate = -1;
+                pawn.YCoordinate = -1; 
+                return;
+            }
+           
+            // Check if there's already a pawn here, if there is set X and Y pos to (-1,-1)
+            try { 
+                if (pieces[xCoordinate, yCoordinate] != null)
+                {
+                    Console.WriteLine($"Pawn already exists at {xCoordinate}, {yCoordinate}");
+                    pawn.XCoordinate = -1;
+                    pawn.YCoordinate = -1;
+                    return;
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Exception caught:" + e.Message + "Source: " + e.Source);
+            }
+
+            //If all cases are successful and we get here, add pawn
+            pawn.XCoordinate = xCoordinate;
+            pawn.YCoordinate = yCoordinate;
+            pawn.PieceColor = pieceColour;
+            pieces[xCoordinate, yCoordinate] = pawn;
         }
 
+        /// <summary>
+        /// Method to validate if the position to add a piece to is valid.
+        /// </summary>
+        /// <param name="xCoordinate"></param>
+        /// <param name="yCoordinate"></param>
+        /// <returns>True or False depending on if position is valid or not</returns>
         public bool IsLegalBoardPosition(int xCoordinate, int yCoordinate)
         {
-            throw new NotImplementedException("Need to implement ChessBoard.IsLegalBoardPosition()");
+            bool isLegal = false;
+            if(
+                (xCoordinate >= 0 & yCoordinate >= 0)
+                && 
+                (xCoordinate <= (MaxBoardWidth -1) & yCoordinate <= (MaxBoardHeight -1))
+                )
+            {
+                isLegal = true;
+            }
+
+            return isLegal;
+
         }
 
     }

--- a/ChessProject-Csharp/src/Pawn.cs
+++ b/ChessProject-Csharp/src/Pawn.cs
@@ -30,7 +30,7 @@ namespace SolarWinds.MSP.Chess
         public PieceColor PieceColor
         {
             get { return pieceColor; }
-            private set { pieceColor = value; }
+            set { pieceColor = value; }
         }
 
         public Pawn(PieceColor pieceColor)
@@ -38,9 +38,84 @@ namespace SolarWinds.MSP.Chess
             this.pieceColor = pieceColor;
         }
 
+        /// <summary>
+        /// Method to move pawn to new place on the board, currently only implemented for move but will hanlde if it is passed a capture command.
+        /// </summary>
+        /// <param name="movementType">Move or Capture accepted, will only execute Move</param>
+        /// <param name="newX">X-Coordinate to move pawn to</param>
+        /// <param name="newY">Y-coordinate to move pawn to</param>
+        /// <exception cref="NotImplementedException">Exception provided if Capture is passed</exception>
         public void Move(MovementType movementType, int newX, int newY)
         {
-            throw new NotImplementedException("Need to implement Pawn.Move()");
+            // Split here based on Movement type
+            switch (movementType)
+            {
+                //Currently only implemented case being handled, if any others throw exception. 
+                case MovementType.Move:
+                    //Check move
+                    bool move = CheckMove(newX, newY, this.pieceColor);
+                    if (move)
+                    {
+                        this.XCoordinate = newX;
+                        this.YCoordinate = newY;
+
+                    }
+
+                    break;
+                case MovementType.Capture: //Not yet implemented but code here to future proof. 
+                    throw new NotImplementedException();
+
+            }
+                      
+        }
+
+        /// <summary>
+        /// Method to check the validity of a Pawn move depending on piece colour.
+        /// Currently only implemented for move, not capture movements. 
+        /// </summary>
+        /// <param name="newX">X-Coordinate to move pawn toX/param>
+        /// <param name="newY">Y-Coordinate to move pawn to</param>
+        /// <returns>True or False depending on if move is valid for a pawn</returns>
+        internal bool CheckMove(int newX, int newY, PieceColor pawnColour)
+        {
+            bool move = false;
+
+            //get pawn pos
+            int currX = this.XCoordinate;
+            int currY = this.YCoordinate;
+            
+            //If moving X coords return early
+            if (newX != currX) // Check we are not going left or right, inform user if we are at this point just a console line.
+            {
+                Console.WriteLine("Illegal move: Cannot move pawn left or right, only forwards");
+                return move;
+            }
+            
+
+            switch (pawnColour)
+            {
+                case PieceColor.Black:
+                    //check new coords are an upward (forward) move, not diagonal or backwards.
+                    // else if statements are only here to provide user information and don't give any functional impact to the code. 
+                    if (newX == currX && newY == (currY - 1))
+                    {
+                        move = true;
+
+                    }
+
+                    break;
+
+                case PieceColor.White:
+                    //check new coords are a downward (forward) move, not diagonal or backwards.
+                    // else if statements are only here to provide user information and don't give any functional impact to the code. 
+                    if (newX == currX && newY == (currY + 1))
+                    {
+                        move = true;
+                    }
+                    break;
+            }
+          
+            return move;
         }
 
         public override string ToString()

--- a/ChessProject-Csharp/tests/ChessBoardTest.cs
+++ b/ChessProject-Csharp/tests/ChessBoardTest.cs
@@ -78,6 +78,7 @@ namespace SolarWinds.MSP.Chess
             Assert.IsFalse(isValidPosition);
 		}
 
+
         [TestMethod]
 		public void Avoids_Duplicate_Positioning()
 		{

--- a/ChessProject-Csharp/tests/ChessTests.csproj
+++ b/ChessProject-Csharp/tests/ChessTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SolarWinds.MSP.Chess</RootNamespace>
     <AssemblyName>SolarWinds.MSP.ChessTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ChessProject-Csharp/tests/PawnTest.cs
+++ b/ChessProject-Csharp/tests/PawnTest.cs
@@ -52,7 +52,7 @@ namespace SolarWinds.MSP.Chess
 		}
 
 		[TestMethod]
-		public void Pawn_Move_LegalCoordinates_Forward_UpdatesCoordinates()
+		public void Pawn_Black_Move_LegalCoordinates_Forward_UpdatesCoordinates()
 		{
 			chessBoard.Add(pawn, 6, 3, PieceColor.Black);
 			pawn.Move(MovementType.Move, 6, 2);
@@ -60,5 +60,23 @@ namespace SolarWinds.MSP.Chess
             Assert.AreEqual(pawn.YCoordinate, 2);
 		}
 
-	}
+        [TestMethod]
+        public void Pawn_White_Move_LegalCoordinates_Forward_UpdatesCoordinates()
+        {
+            chessBoard.Add(pawn, 6, 3, PieceColor.White);
+            pawn.Move(MovementType.Move, 6, 4);
+            Assert.AreEqual(pawn.XCoordinate, 6);
+            Assert.AreEqual(pawn.YCoordinate, 4);
+        }
+
+        [TestMethod]
+		[ExpectedException(typeof(NotImplementedException))]
+        public void Pawn_Capture_LegalCoordinates_Forward_UpdatesCoordinates()
+        {
+            chessBoard.Add(pawn, 6, 3, PieceColor.Black);
+            pawn.Move(MovementType.Capture, 6, 2);
+			
+        }
+        		
+    }
 }


### PR DESCRIPTION
Functions implemented:
- Chessboard.add() - calls Chessboard.IsLegalBoardPosition() to ensure position is legal, checks a piece isn't already present there - if conditions are met, adds to board.

- Chessboard.IsLegalBoardPosition() - Ensures that the coordinates a piece is being added to are valid within the confines of the chessboard max height and max width.

- Pawn.Move() - Moves a pawn to new coordinates if these are valid for a pawn move. Uses Pawn.CheckMove() to validate move.

- Pawn.CheckMove() - Validates if pawn move is valid, pawns can only move forward one space (upwards or down depending on colour).

Refactored to make  PieceColor setter public and to make pieces internal as opposed to private within Chessboard.cs. Also pointed the solution to .Net Framework 4.8. 